### PR TITLE
TCP keepalive enabled by default

### DIFF
--- a/src/task/net.c
+++ b/src/task/net.c
@@ -252,6 +252,9 @@ int netaccept(int fd, char *server, int *port)
         }
     }
 
+    int keepalive = 1;
+	  setsockopt(cfd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
+	
     fdnoblock(cfd);
 
     if(SET_NODELAY) {


### PR DESCRIPTION
In some scenarios it's very important to enable the TCP keepalive packets on every accepted connection. I don't know enough about the Mongrel2 project to make it as an option, so I enabled it by default.
